### PR TITLE
fix AWS Secret key name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The container is set up by setting environment variables and volumes.
 | `MSMTP_ARGS`               | SMTP settings for mail notification             | `--host=x --port=587 ... cdb@seatable.io`                         |                   |
 | `AWS_DEFAULT_REGION`       | Required only for S3 backend                    | `eu-west-1`                                                       |                   |
 | `AWS_ACCESS_KEY_ID`        | Required only for S3 backend                    |                                                                   |                   |
-| `AWS_SECRET_ACCESS_KEY_ID` | Required only for S3 backend                    |                                                                   |                   |
+| `AWS_SECRET_ACCESS_KEY`    | Required only for S3 backend                    |                                                                   |                   |
 | `B2_ACCOUNT_ID`            | Required only for backblaze backend             |                                                                   |                   |
 | `B2_ACCOUNT_KEY`           | Required only for backblaze backend             |                                                                   |                   |
 


### PR DESCRIPTION
The readme shows `AWS_SECRET_ACCESS_KEY_ID` as ENV Variable but the correct name is AWS_SECRET_ACCESS_KEY
Restic complains with 

```
Fatal: unable to open S3 backend: Secret ($AWS_SECRET_ACCESS_KEY) is empty
```